### PR TITLE
Don't create new task for defaults env

### DIFF
--- a/lib/capistrano/af83/stages.rb
+++ b/lib/capistrano/af83/stages.rb
@@ -57,4 +57,4 @@ namespace :multistage do
   end
 end
 
-on :start, "multistage:ensure"
+on :start, "multistage:ensure", except: default_stages + stages

--- a/lib/capistrano/af83/stages.rb
+++ b/lib/capistrano/af83/stages.rb
@@ -38,10 +38,12 @@ task :prod do
 end
 
 stages.each do |name|
-  desc "Set the target stage to `#{name}'."
-  task(name) do
-    set :stage, name.to_sym
-    load "#{location}/#{stage}"
+  unless default_stages.include?(name.to_sym)
+    desc "Set the target stage to `#{name}'."
+    task(name) do
+      set :stage, name.to_sym
+      load "#{location}/#{stage}"
+    end
   end
 end
 


### PR DESCRIPTION
If a file in config/deploy/ is present to overload some parameters, cap
task must not be created on the fly to prevent from loosing default
params.
